### PR TITLE
fix release workflow - take 2

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -33,10 +33,3 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GITHUB }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-            - name: Merge main into beta
-              run: |
-                  git fetch origin
-                  git checkout beta
-                  git merge --no-ff origin/main -m "chore: Merge branch 'main' into beta"
-                  git push origin beta

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -23,6 +23,7 @@ module.exports = {
             "@semantic-release/exec",
             {
                 prepareCmd: "typedoc --out docs",
+                successCmd: "git checkout beta && git merge main && git push origin beta",
             },
         ],
         "@semantic-release/npm",


### PR DESCRIPTION
We have to set `persist-credentials: false` in the GitHub Action workflow.
Needed to allow Semantics Release to manage auth.
But this prevents the action from having permission to do a push.
Hence we will get Semantic Release to do it.